### PR TITLE
feat: Resolver validations

### DIFF
--- a/src/interfaces/IBadgeRegistry.sol
+++ b/src/interfaces/IBadgeRegistry.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IBadgeRegistry {
+  error BadgeAlreadyRegistered();
+
+  event BadgeRegistered(bytes32 indexed badgeId, address indexed issuer, string name);
+
+  struct Badge {
+    string name;
+    string description;
+    string metadata;
+    bytes data;
+  }
+
+  function badgeExists(bytes32 badgeId) external view returns (bool);
+}

--- a/src/interfaces/IGrantRegistry.sol
+++ b/src/interfaces/IGrantRegistry.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface IGrantRegistry {
+  struct Grant {
+    uint256 chain; // Blockchain network where the grant is being developed
+    address grantee; // Address of the person responsible for delivering and receiving the grant reward
+    string grantProgramLabel; // Name of the protocol/community that issued the grant
+    string project; // Name/Title of the project or company that received the grant
+    string[] externalLinks; // Link that redirects to the grant proposal, discussion or relative
+    uint256 startDate; // Start date for the grant development
+    uint256 endDate; // Expected completion date for the grant
+    Status status; // Current status of the grant
+    Disbursement disbursements; // Disbursement stages based on milestones
+  }
+
+  enum Status {
+    Proposed, // The grant has been proposed but not yet approved (Default)
+    InProgress, // The project is actively being worked on
+    Completed, // The project has been completed and deliverables submitted
+    Cancelled, // The grant was cancelled
+    Rejected // The grant proposal was reviewed and rejected
+  }
+
+  struct Disbursement {
+    address[] fundingTokens; // Tokens that will be disbursed in this stage
+    uint256[] fundingAmounts; // Amounts of tokens to be disbursed in this stage
+    bool[] disbursed; // Indicates if the disbursement has been made in this stage
+  }
+
+  function getGrant(bytes32 grantId) external view returns (Grant memory);
+}

--- a/src/interfaces/ITrustfulResolver.sol
+++ b/src/interfaces/ITrustfulResolver.sol
@@ -1,0 +1,12 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.25;
+
+interface ITrustfulResolver {
+  function createStory(
+    bytes32 txUID,
+    bytes32[] calldata badges,
+    uint8[] calldata badgeScores,
+    string memory grantProgramLabel
+  ) external;
+}

--- a/test/Registry.t.sol
+++ b/test/Registry.t.sol
@@ -6,20 +6,32 @@ import { Resolver } from "../src/resolver/Resolver.sol";
 import { IResolver } from "../src/interfaces/IResolver.sol";
 import { ISchemaRegistry } from "../src/interfaces/ISchemaRegistry.sol";
 import { IEAS } from "../src/interfaces/IEAS.sol";
+import { IGrantRegistry } from "../src/interfaces/IGrantRegistry.sol";
+import { IBadgeRegistry } from "../src/interfaces/IBadgeRegistry.sol";
+import { ITrustfulResolver } from "../src/interfaces/ITrustfulResolver.sol";
 import { Resolver } from "../src/resolver/Resolver.sol";
 
 contract RegistryTest is Test {
   IEAS eas = IEAS(0xbD75f629A22Dc1ceD33dDA0b68c546A1c035c458);
   ISchemaRegistry schemaRegistry = ISchemaRegistry(0xA310da9c5B885E7fb3fbA9D66E9Ba6Df512b78eB);
+  IGrantRegistry grantRegistry = IGrantRegistry(0x399629485D6B5b6209c4cbEFf5C04ccbc97d390F);
+  IBadgeRegistry badgeRegistry = IBadgeRegistry(0xFD885f03b7ce1eA0D0f7Ca17E032F8Ce322886AF);
+  ITrustfulResolver trustfulResolver =
+    ITrustfulResolver(0x0000000000000000000000000000000000000000);
   Resolver resolver;
 
   function setUp() public {
     vm.startPrank(0x06a1aD4b9Ed1733F6359E00F1573Fa3F8697903B);
-    resolver = new Resolver(eas);
+    resolver = new Resolver(
+      eas,
+      address(grantRegistry),
+      address(badgeRegistry),
+      address(trustfulResolver)
+    );
   }
 
-  function test_registry_mocked_schema_review() public {
-    string memory schema = "string review,uints score";
+  function test_registry_badges() public {
+    string memory schema = "bytes32[] badges,uint8[] score";
     bool revocable = true;
 
     bytes32 uid = schemaRegistry.register(schema, resolver, revocable);


### PR DESCRIPTION
Inside the `attest` function of the `Resolver.sol` we are checking the following conditions:

- [x] Checking if a badge exists 
- [x] Checking if the grantee is not the attester
- [x] Checking if status is `Proposed` if so, revert transaction
- [x] Checking if status is `Completed`, `Canceled`, or `Rejected`, if so, allow the user to make one last review
